### PR TITLE
Support YAML by default

### DIFF
--- a/lib/kumogata2.rb
+++ b/lib/kumogata2.rb
@@ -19,5 +19,6 @@ require 'kumogata2/utils'
 
 require 'kumogata2/plugin'
 require 'kumogata2/plugin/json'
+require 'kumogata2/plugin/yaml'
 
 require 'kumogata2/client'

--- a/lib/kumogata2/plugin/yaml.rb
+++ b/lib/kumogata2/plugin/yaml.rb
@@ -1,0 +1,16 @@
+require 'yaml'
+class Kumogata2::Plugin::YAML
+  Kumogata2::Plugin.register(:yaml, ['yaml', 'yml'], self)
+
+  def initialize(options)
+    @options = options
+  end
+
+  def parse(str)
+    YAML.load(str)
+  end
+
+  def dump(hash)
+    YAML.dump(hash).colorize_as(:yaml)
+  end
+end


### PR DESCRIPTION
公式がYAMLサポートをしたので、せっかくだから標準対応というPRです。

ただこちらを実装しただけです。
http://so-wh.at/entry/2016/04/30/Kumogata2

一応制限事項があり、YAMLをロードする再に消えちゃうため短縮形(`!Sub`など)が利用できません。