### PR TITLE
Fix the problem that the AWS options does not work

### DIFF
--- a/lib/kumogata2/cli/option_parser.rb
+++ b/lib/kumogata2/cli/option_parser.rb
@@ -174,7 +174,7 @@ module Kumogata2::CLI
         options[:aws][:credentials] = credentials
       end
 
-      Aws.config.update(options[:aws].dup)
+      options[:aws].each {|k,v| Aws.config[k.to_sym] = v }
       options = Hashie::Mash.new(options)
 
       String.colorize = options.color?


### PR DESCRIPTION
The following options did not work.

* `--region`
* `--access-key`
* `--secret-key`

For example (`--region`):

```
$ AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxxx \
  AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
  kumogata2 create foo.rb foo \
  --region ap-northeast-1
Creating stack: foo
[ERROR] missing region; use :region option or export region name to ENV['AWS_REGION']
```

For example (`--access-key`, `--secret-key`):

```
$ AWS_REGION=ap-northeast-1 \
  kumogata2 create foo.rb foo \
  --access-key xxxxxxxxxxxxxxxxxxxx \
  --secret-key xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Creating stack: foo
[ERROR] unable to sign request without credentials set
```

This pull-request fixes it.
