### PR TITLE
add region and profile information

### DIFF
--- a/lib/kumogata2/client.rb
+++ b/lib/kumogata2/client.rb
@@ -150,7 +150,7 @@ class Kumogata2::Client
 
   def get_client
     return @client unless @client.nil?
-    @client = Aws::CloudFormation::Client.new
+    @client = Aws::CloudFormation::Client.new(@options.aws)
   end
 
   def get_resource


### PR DESCRIPTION
## TL;DL

Fixed a problem that does not call profile information even if profile is specified.

## precondition

~/.aws/credentials
```
[kumogata]
aws_access_key_id = xxxxxxxxxxxxxxxx
aws_secret_access_key = xxxxxxxxxxxxxxxx
```

## failure case

`kumogata2 list --region ap-northeast-1 --profile kumogata`
=> `[ERROR] unable to sign request without credentials set`

```ruby
    151: def get_client
    152:   return @client unless @client.nil?
    153:   require 'pry'; binding.pry
 => 154:   @client = Aws::CloudFormation::Client.new
    155: end

[1] pry(#<Kumogata2::Client>)> @options.aws
=> {"region"=>"ap-northeast-1", "credentials"=>#<Aws::SharedCredentials profile_name="kumogata" path="/Users/8398a7/.aws/credentials">}
```

